### PR TITLE
Add new Under water hints to guide

### DIFF
--- a/hints.html
+++ b/hints.html
@@ -174,6 +174,8 @@
         <li><b>...is under some rocks</b>: Pegasus Rocks (west of the sanctuary)</li>
         <li><b>...is under water</b>:
             <ul>
+                <li>Catfish</li>
+                <li>King Zora</li>
                 <li>The sunken treasure near the dam</li>
                 <li>Swamp Palace: the two flooded chests in back</li>
                 <li>Waterfall Fairy</li>


### PR DESCRIPTION
Under water can be the Catfish and King Zora since v30.4.  This fixes https://github.com/arborelia/alttpr/issues/7